### PR TITLE
Fix #10: Parse month correctly

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -3,7 +3,8 @@ module.exports.arrayFrom$row = function arrayFrom$row($, $row) {
 }
 
 module.exports.parseDate = function parseDate(text) {
-  return new Date(...text.split('/').reverse())
+  const [d, m, y] = text.split('/', 3).map(e => parseInt(e, 10))
+  return new Date(y, m - 1, d)
 }
 
 module.exports.parseAmount = function parseAmount(amount) {


### PR DESCRIPTION
Fixes #10
Should fix #11 (entries were saved using `parseDate`)