### PR TITLE
chore(manifest): add a banksTransactionRegExp property

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -86,5 +86,6 @@
       }
     }
   },
+  "banksTransactionRegExp": "\\bgenerali\\b",
   "manifest_version": "2"
 }


### PR DESCRIPTION
In banks, we currently use a [brands dictionnary](https://github.com/cozy/cozy-banks/blob/master/src/ducks/brandDictionary/brands.json) to list the potential connectors that the user can potentially connect. In a near future, we will use the [appropriate stack route](https://docs.cozy.io/en/cozy-stack/registry/#apis-querying-registry) to dynamically fetch the connectors list with their manifest. But in order to do that, we need to add a regexp (that we use to do the matching between a banking transaction label and a connector) in the manifest of the connectors. That's the purpose of this PR.

We named it `banksTransactionRegExp` because that's the purpose it serves and we had a hard time finding a name. If you see something better, don't hesitate.